### PR TITLE
Add support to BlueN64 controllers

### DIFF
--- a/main/adapter/adapter.h
+++ b/main/adapter/adapter.h
@@ -279,6 +279,7 @@ enum {
     BT_QUIRK_SW_RIGHT_JOYCON,
     BT_QUIRK_8BITDO_N64,
     BT_QUIRK_8BITDO_M30,
+    BT_QUIRK_BLUEN64_N64,
 };
 
 /* Wired flags */

--- a/main/adapter/mapping_quirks.c
+++ b/main/adapter/mapping_quirks.c
@@ -122,6 +122,17 @@ static void m30_8bitdo(struct raw_src_mapping *map) {
     map->axes_to_btns[TRIG_R] = PAD_RB_RIGHT;
 }
 
+static void n64_bluen64(struct raw_src_mapping *map) {
+    map->mask[0] = 0x23150FFF;
+    map->desc[0] = 0x000000FF;
+
+    map->btns_mask[PAD_RB_LEFT] = map->btns_mask[PAD_RB_RIGHT];
+    map->btns_mask[PAD_RX_LEFT] = BIT(3);
+    map->btns_mask[PAD_RY_DOWN] = BIT(4);
+    map->btns_mask[PAD_LM] = BIT(8);
+    map->btns_mask[PAD_MM] = BIT(5);
+}
+
 void mapping_quirks_apply(struct bt_data *bt_data) {
     if (atomic_test_bit(&bt_data->base.flags[PAD], BT_QUIRK_FACE_BTNS_INVERT)) {
         face_btns_invert(&bt_data->raw_src_mappings[PAD]);
@@ -146,5 +157,8 @@ void mapping_quirks_apply(struct bt_data *bt_data) {
     }
     if (atomic_test_bit(&bt_data->base.flags[PAD], BT_QUIRK_8BITDO_M30)) {
         m30_8bitdo(&bt_data->raw_src_mappings[PAD]);
+    }
+    if (atomic_test_bit(&bt_data->base.flags[PAD], BT_QUIRK_BLUEN64_N64)) {
+        n64_bluen64(&bt_data->raw_src_mappings[PAD]);
     }
 }

--- a/main/bluetooth/hci.c
+++ b/main/bluetooth/hci.c
@@ -69,6 +69,7 @@ static const struct bt_name_type bt_name_type[] = {
     {"8BitDo M30 gamepad", BT_XBOX, BT_XBOX_XINPUT, BIT(BT_QUIRK_8BITDO_M30)},
     {"Retro Bit Bluetooth Controller", BT_XBOX, BT_XBOX_XINPUT, BIT(BT_QUIRK_FACE_BTNS_TRIGGER_TO_6BUTTONS) | BIT(BT_QUIRK_TRIGGER_PRI_SEC_INVERT)},
     {"Joy Controller", BT_XBOX, BT_XBOX_XINPUT, 0},
+    {"BlueN64 Gamepad", BT_HID_GENERIC, BT_SUBTYPE_DEFAULT, BIT(BT_QUIRK_BLUEN64_N64)},
 };
 
 static const struct bt_hci_cp_set_event_filter clr_evt_filter = {


### PR DESCRIPTION
This adds support for the [BlueN64 controllers](https://github.com/JPZV/Blue-N64-Control-ESP32), which are originals Nintendo 64 controllers but with an ESP32 on it.

Main Changes:

- Added `BT_BLUEN64_N64` BT flag
- Created new mapping quirk called `n64_bluen64`
- Added `BlueN64 Gamepad` Bluetooth device to the supported controllers

Tested with:

- Config: HW1 N64
- Nintendo 64 (works instantly, no remapping from the final user needed)
- _Nintendo GameCube_ and _GameCube Controller Adapter_ (both need to remap L, R and Z. More info in #526)