### PR TITLE
Added support for the BluControl project

### DIFF
--- a/main/bluetooth/hci.c
+++ b/main/bluetooth/hci.c
@@ -70,6 +70,7 @@ static const struct bt_name_type bt_name_type[] = {
     {"Retro Bit Bluetooth Controller", BT_XBOX, BT_XBOX_XINPUT, BIT(BT_QUIRK_FACE_BTNS_TRIGGER_TO_6BUTTONS) | BIT(BT_QUIRK_TRIGGER_PRI_SEC_INVERT)},
     {"Joy Controller", BT_XBOX, BT_XBOX_XINPUT, 0},
     {"BlueN64 Gamepad", BT_HID_GENERIC, BT_SUBTYPE_DEFAULT, BIT(BT_QUIRK_BLUEN64_N64)},
+    {"BluControl Gamepad", BT_HID_GENERIC, BT_SUBTYPE_DEFAULT, 0},
 };
 
 static const struct bt_hci_cp_set_event_filter clr_evt_filter = {


### PR DESCRIPTION
This adds support for the [BluControl project](https://github.com/JPZV/BluControl-ESP32) (At the time of writing this, the repository is private due to partnership concerns, but it'll be public soon), which is based on [BlueN64](https://github.com/JPZV/Blue-N64-Control-ESP32) but for every type of controller, like self-made or retro one, all by using ESP32 and with minimal coding.

Main Changes:

- Added `BluControl Gamepad` Bluetooth device to the supported controllers

Tested with:

- Config: HW1 PSX/PS2
- PlayStation 2 with DualShock 2 (works instantly, no remapping from the final user needed)
- Not tested, but any mapping based on Nintendo Switch Pro Controller should work instantly. The idea is that the map must be done from the BluControl project instead of from RetroBlue.







