### PR TITLE
Add HID_C/HID_Z buttons in generic bluetooth controllers

### DIFF
--- a/main/adapter/wired/n64.c
+++ b/main/adapter/wired/n64.c
@@ -64,13 +64,13 @@ struct n64_kb_map {
     uint8_t bitfield;
 } __packed;
 
-static const uint32_t n64_mask[4] = {0x33DF0FFF, 0x00000000, 0x00000000, 0x00000000};
+static const uint32_t n64_mask[4] = {0x33DFAFFF, 0x00000000, 0x00000000, 0x00000000};
 static const uint32_t n64_desc[4] = {0x0000000F, 0x00000000, 0x00000000, 0x00000000};
 static DRAM_ATTR const uint32_t n64_btns_mask[32] = {
     0, 0, 0, 0,
     BIT(N64_C_LEFT), BIT(N64_C_RIGHT), BIT(N64_C_DOWN), BIT(N64_C_UP),
     BIT(N64_LD_LEFT), BIT(N64_LD_RIGHT), BIT(N64_LD_DOWN), BIT(N64_LD_UP),
-    0, 0, 0, 0,
+    0, BIT(N64_C_RIGHT), 0, BIT(N64_C_UP),
     BIT(N64_B), BIT(N64_C_DOWN), BIT(N64_A), BIT(N64_C_LEFT),
     BIT(N64_START), 0, 0, 0,
     BIT(N64_Z), BIT(N64_L), 0, 0,

--- a/main/adapter/wireless/hid_generic.c
+++ b/main/adapter/wireless/hid_generic.c
@@ -83,7 +83,7 @@ static const uint32_t hid_pad_default_btns_mask[32] = {
     0, 0, 0, 0,
     0, 0, 0, 0,
     0, 0, 0, 0,
-    0, 0, 0, 0,
+    0, BIT(HID_Z), 0, BIT(HID_C),
     BIT(HID_X), BIT(HID_B), BIT(HID_A), BIT(HID_Y),
     BIT(HID_START), BIT(HID_SELECT), BIT(HID_MENU), 0,
     BIT(HID_L), BIT(HID_LB), 0, BIT(HID_LJ),
@@ -446,7 +446,7 @@ static void hid_pad_init(struct hid_report_meta *meta, struct hid_report *report
         uint32_t hid_mask = (1 << report->usages[meta->hid_btn_idx].bit_size) - 1;
 
         /* Use a good default for most modern controller */
-        for (uint32_t i = 16; i < ARRAY_SIZE(generic_btns_mask); i++) {
+        for (uint32_t i = 12; i < ARRAY_SIZE(generic_btns_mask); i++) {
             if (hid_pad_default_btns_mask[i] && !(map->mask[0] & BIT(i))) {
                 map->mask[0] |= BIT(i);
                 map->btns_mask[i] = hid_pad_default_btns_mask[i];
@@ -455,7 +455,7 @@ static void hid_pad_init(struct hid_report_meta *meta, struct hid_report *report
         }
 
         /* fillup what is left */
-        for (uint32_t mask = (1U << 16), btn = 0, i = 16; mask && btn < report->usages[meta->hid_btn_idx].bit_size; mask <<= 1, i++) {
+        for (uint32_t mask = (1U << 12), btn = 0, i = 12; mask && btn < report->usages[meta->hid_btn_idx].bit_size; mask <<= 1, i++) {
             while (!(hid_mask & BIT(btn))) {
                 btn++;
                 if (btn >= report->usages[meta->hid_btn_idx].bit_size) {


### PR DESCRIPTION
Let's start with some context.

I have this [controller](https://retrofighters.com/our-collection/brawler64-usb/), unfortunately it stopped working and I didn't find the problem, so I had the idea of converting it to bluetooth with the help of the BleGamepad library.

When reviewing the code, I see that the HID_C and HID_Z buttons are missing for the Generic HDI bluetooh controller, my suggestion is to add them in the PAD_LT and PAD_RT position with the intention of adding the missing C-Up and C-Right buttons on Nintendo 64 and on other possible controllers without affecting the operation and expanding more buttons for functions.

I understand that I can emulate a second joystick and map to the C buttons to get them, but I would like to have the option as digital similar to C-Left and C-Down

I hope it helps or that the support of the C and Z buttons can be expanded