### PR TITLE
Fix to m30 8bit Dinput Mode

### DIFF
--- a/main/adapter/mapping_quirks.c
+++ b/main/adapter/mapping_quirks.c
@@ -229,7 +229,7 @@ void mapping_quirks_apply(struct bt_data *bt_data) {
     if (atomic_test_bit(&bt_data->base.flags[PAD], BT_QUIRK_RF_WARRIOR)) {
         rf_warrior(&bt_data->raw_src_mappings[PAD]);
     }
-        if (atomic_test_bit(&bt_data->base.flags[PAD], BT_QUIRK_STADIA)) {
+    if (atomic_test_bit(&bt_data->base.flags[PAD], BT_QUIRK_STADIA)) {
         stadia(&bt_data->raw_src_mappings[PAD]);
     }
 }

--- a/main/adapter/mapping_quirks.c
+++ b/main/adapter/mapping_quirks.c
@@ -156,6 +156,42 @@ static void rf_warrior(struct raw_src_mapping *map) {
     map->btns_mask[PAD_MS] = 0;
 }
 
+enum {
+    STADIA_CAPTURE = 0,
+    STADIA_ASSISTANT,
+    STADIA_LT_L2,
+    STADIA_RT_R2,
+    STADIA_STADIA,
+    STADIA_MENU,
+    STADIA_OPTIONS,
+    STADIA_R3,
+    STADIA_L3,
+    STADIA_RB_R1,
+    STADIA_LB_L1,
+    STADIA_Y,
+    STADIA_X,
+    STADIA_B,
+    STADIA_A,
+};
+
+static void stadia(struct raw_src_mapping *map) {
+    map->btns_mask[PAD_RD_LEFT] = BIT(STADIA_CAPTURE);
+    map->btns_mask[PAD_RB_LEFT] = BIT(STADIA_X);
+    map->btns_mask[PAD_RB_RIGHT] = BIT(STADIA_B);
+    map->btns_mask[PAD_RB_DOWN] = BIT(STADIA_A);
+    map->btns_mask[PAD_RB_UP] = BIT(STADIA_Y);
+    map->btns_mask[PAD_MM] = BIT(STADIA_MENU);
+    map->btns_mask[PAD_MS] = BIT(STADIA_OPTIONS);
+    map->btns_mask[PAD_MT] = BIT(STADIA_STADIA);
+    map->btns_mask[PAD_MQ] = BIT(STADIA_ASSISTANT);
+    map->btns_mask[PAD_LM] = 0;
+    map->btns_mask[PAD_LS] = BIT(STADIA_LB_L1);
+    map->btns_mask[PAD_LJ] = BIT(STADIA_L3);
+    map->btns_mask[PAD_RM] = 0;
+    map->btns_mask[PAD_RS] = BIT(STADIA_RB_R1);
+    map->btns_mask[PAD_RJ] = BIT(STADIA_R3);
+}
+
 void mapping_quirks_apply(struct bt_data *bt_data) {
     if (atomic_test_bit(&bt_data->base.flags[PAD], BT_QUIRK_FACE_BTNS_INVERT)) {
         face_btns_invert(&bt_data->raw_src_mappings[PAD]);
@@ -192,5 +228,8 @@ void mapping_quirks_apply(struct bt_data *bt_data) {
     }
     if (atomic_test_bit(&bt_data->base.flags[PAD], BT_QUIRK_RF_WARRIOR)) {
         rf_warrior(&bt_data->raw_src_mappings[PAD]);
+    }
+        if (atomic_test_bit(&bt_data->base.flags[PAD], BT_QUIRK_STADIA)) {
+        stadia(&bt_data->raw_src_mappings[PAD]);
     }
 }

--- a/main/adapter/mapping_quirks.c
+++ b/main/adapter/mapping_quirks.c
@@ -156,42 +156,6 @@ static void rf_warrior(struct raw_src_mapping *map) {
     map->btns_mask[PAD_MS] = 0;
 }
 
-enum {
-    STADIA_CAPTURE = 0,
-    STADIA_ASSISTANT,
-    STADIA_LT_L2,
-    STADIA_RT_R2,
-    STADIA_STADIA,
-    STADIA_MENU,
-    STADIA_OPTIONS,
-    STADIA_R3,
-    STADIA_L3,
-    STADIA_RB_R1,
-    STADIA_LB_L1,
-    STADIA_Y,
-    STADIA_X,
-    STADIA_B,
-    STADIA_A,
-};
-
-static void stadia(struct raw_src_mapping *map) {
-    map->btns_mask[PAD_RD_LEFT] = BIT(STADIA_CAPTURE);
-    map->btns_mask[PAD_RB_LEFT] = BIT(STADIA_X);
-    map->btns_mask[PAD_RB_RIGHT] = BIT(STADIA_B);
-    map->btns_mask[PAD_RB_DOWN] = BIT(STADIA_A);
-    map->btns_mask[PAD_RB_UP] = BIT(STADIA_Y);
-    map->btns_mask[PAD_MM] = BIT(STADIA_MENU);
-    map->btns_mask[PAD_MS] = BIT(STADIA_OPTIONS);
-    map->btns_mask[PAD_MT] = BIT(STADIA_STADIA);
-    map->btns_mask[PAD_MQ] = BIT(STADIA_ASSISTANT);
-    map->btns_mask[PAD_LM] = 0;
-    map->btns_mask[PAD_LS] = BIT(STADIA_LB_L1);
-    map->btns_mask[PAD_LJ] = BIT(STADIA_L3);
-    map->btns_mask[PAD_RM] = 0;
-    map->btns_mask[PAD_RS] = BIT(STADIA_RB_R1);
-    map->btns_mask[PAD_RJ] = BIT(STADIA_R3);
-}
-
 void mapping_quirks_apply(struct bt_data *bt_data) {
     if (atomic_test_bit(&bt_data->base.flags[PAD], BT_QUIRK_FACE_BTNS_INVERT)) {
         face_btns_invert(&bt_data->raw_src_mappings[PAD]);
@@ -215,7 +179,10 @@ void mapping_quirks_apply(struct bt_data *bt_data) {
         n64_8bitdo(&bt_data->raw_src_mappings[PAD]);
     }
     if (atomic_test_bit(&bt_data->base.flags[PAD], BT_QUIRK_8BITDO_M30)) {
-        m30_8bitdo(&bt_data->raw_src_mappings[PAD]);
+        /* Only load this quirk if 8bitdo is connected in xinput mode */
+        if (bt_data->base.report_id == 0x01) {
+            m30_8bitdo(&bt_data->raw_src_mappings[PAD]);
+        }
     }
     if (atomic_test_bit(&bt_data->base.flags[PAD], BT_QUIRK_8BITDO_SATURN)) {
         saturn_diy_8bitdo(&bt_data->raw_src_mappings[PAD]);
@@ -225,8 +192,5 @@ void mapping_quirks_apply(struct bt_data *bt_data) {
     }
     if (atomic_test_bit(&bt_data->base.flags[PAD], BT_QUIRK_RF_WARRIOR)) {
         rf_warrior(&bt_data->raw_src_mappings[PAD]);
-    }
-    if (atomic_test_bit(&bt_data->base.flags[PAD], BT_QUIRK_STADIA)) {
-        stadia(&bt_data->raw_src_mappings[PAD]);
     }
 }

--- a/main/bluetooth/hidp/hidp.c
+++ b/main/bluetooth/hidp/hidp.c
@@ -51,6 +51,7 @@ static const struct bt_name_type bt_name_type[] = {
     {"Joy Controller", BT_XBOX, BT_XBOX_XINPUT, BIT(BT_QUIRK_RF_WARRIOR)},
     {"BlueN64 Gamepad", BT_HID_GENERIC, BT_SUBTYPE_DEFAULT, BIT(BT_QUIRK_BLUEN64_N64)},
     {"Hyperkin Pad", BT_SW, BT_SW_HYPERKIN_ADMIRAL, 0},
+    {"Stadia", BT_HID_GENERIC, BT_SUBTYPE_DEFAULT, BIT(BT_QUIRK_STADIA)},
 #endif
 };
 

--- a/main/bluetooth/hidp/hidp.c
+++ b/main/bluetooth/hidp/hidp.c
@@ -41,14 +41,16 @@ static const struct bt_name_type bt_name_type[] = {
     {"8BitDo N30 Modkit", BT_XBOX, BT_XBOX_XINPUT, BIT(BT_QUIRK_FACE_BTNS_ROTATE_RIGHT)},
     {"8BitDo GBros Adapter", BT_XBOX, BT_8BITDO_GBROS, 0},
     {"8Bitdo N64 GamePad", BT_HID_GENERIC, BT_SUBTYPE_DEFAULT, BIT(BT_QUIRK_8BITDO_N64)},
-    {"8BitDo M30 gamepad", BT_XBOX, BT_XBOX_XINPUT, BIT(BT_QUIRK_8BITDO_M30)},
+    {"8BitDo M30 gamepad", BT_HID_GENERIC, BT_SUBTYPE_DEFAULT, BIT(BT_QUIRK_8BITDO_M30)}, 
+    /* With BT_XBOX, BT_XBOX_XINPUT, when 8bitdo m30 connected in dinput mode Blueretro wasn't registering any button press (only worked in xinput or switch modes)
+    Changing to generic, I was able to use the controller in xinput mode or dinput mode
+    Since 8bitdo firmware 1.15 the button mappings are different in dinput or xinput modes - made some changes do load the quirk only in xinput mode - see mapping_quirks.c */
     {"8BitDo S30 Modkit", BT_XBOX, BT_XBOX_XINPUT, BIT(BT_QUIRK_8BITDO_SATURN)},
     {"8Bitdo", BT_XBOX, BT_XBOX_XINPUT, 0}, /* 8bitdo catch all, tested with SF30 Pro */
     {"Retro Bit Bluetooth Controller", BT_XBOX, BT_XBOX_XINPUT, BIT(BT_QUIRK_FACE_BTNS_TRIGGER_TO_6BUTTONS) | BIT(BT_QUIRK_TRIGGER_PRI_SEC_INVERT)},
     {"Joy Controller", BT_XBOX, BT_XBOX_XINPUT, BIT(BT_QUIRK_RF_WARRIOR)},
     {"BlueN64 Gamepad", BT_HID_GENERIC, BT_SUBTYPE_DEFAULT, BIT(BT_QUIRK_BLUEN64_N64)},
     {"Hyperkin Pad", BT_SW, BT_SW_HYPERKIN_ADMIRAL, 0},
-    {"Stadia", BT_HID_GENERIC, BT_SUBTYPE_DEFAULT, BIT(BT_QUIRK_STADIA)},
 #endif
 };
 


### PR DESCRIPTION
Made changes to make 8Bit Do M30 work in XInput or Dinput mode. The problem (for me at least) is that Blueretro wasn't registering any button press when paired M30 was paired in Dinput (only worked in xinput or switch modes).

Changing to generic hid, I was able to use the controller in xinput mode or dinput mode.

Since 8bitdo firmware 1.15 the button mappings are different for dinput or xinput modes - so I made some changes do load the quirk only in xinput mode - see mapping_quirks.c 

Maybe it could prove useful, but fell free do throw this away :)