### PR TITLE
Add DualSense trigger effects

### DIFF
--- a/main/adapter/adapter.c
+++ b/main/adapter/adapter.c
@@ -237,6 +237,16 @@ int32_t btn_id_to_axis(uint8_t btn_id) {
     return AXIS_NONE;
 }
 
+uint8_t btn_is_axis(uint8_t dst_id, uint8_t dst_btn) {
+    struct generic_ctrl *out = &ctrl_output[dst_id];
+    uint32_t dst_mask = BIT(dst_btn & 0x1F);
+    uint32_t dst_btn_idx = btn_id_to_btn_idx(dst_btn);
+    if (dst_mask & out->desc[dst_btn_idx]) {
+        return 1;
+    }
+    return 0;
+}
+
 uint32_t axis_to_btn_mask(uint8_t axis) {
     switch (axis) {
         case AXIS_LX:

--- a/main/adapter/adapter.h
+++ b/main/adapter/adapter.h
@@ -517,6 +517,7 @@ extern struct bt_adapter bt_adapter;
 extern struct wired_adapter wired_adapter;
 
 int32_t btn_id_to_axis(uint8_t btn_id);
+uint8_t btn_is_axis(uint8_t dst_id, uint8_t dst_btn_id);
 uint32_t axis_to_btn_mask(uint8_t axis);
 uint32_t axis_to_btn_id(uint8_t axis);
 int8_t btn_sign(uint32_t polarity, uint8_t btn_id);

--- a/main/bluetooth/hidp/ps.h
+++ b/main/bluetooth/hidp/ps.h
@@ -44,9 +44,33 @@ struct bt_hidp_ps5_set_conf {
     uint8_t l_rumble;
     uint8_t tbd0[4];
     uint8_t mic_led;
-    uint8_t tbd1[35];
+    uint8_t tbd1; // Mic/audio mute
+    uint8_t r2_trigger_motor_mode;
+    uint8_t r2_trigger_start_resistance;
+    uint8_t r2_trigger_effect_force;
+    uint8_t r2_trigger_range_force;
+    uint8_t r2_trigger_near_release_str;
+    uint8_t r2_trigger_near_middle_str;
+    uint8_t r2_trigger_pressed_str;
+    uint8_t tbd2[2];
+    uint8_t r2_trigger_actuation_freq;
+    uint8_t tbd3;
+    uint8_t l2_trigger_motor_mode;
+    uint8_t l2_trigger_start_resistance;
+    uint8_t l2_trigger_effect_force;
+    uint8_t l2_trigger_range_force;
+    uint8_t l2_trigger_near_release_str;
+    uint8_t l2_trigger_near_middle_str;
+    uint8_t l2_trigger_pressed_str;
+    uint8_t tbd4[2];
+    uint8_t l2_trigger_actuation_freq;
+    uint8_t tbd5[5];
+    uint8_t l2_haptic_power_level;
+    uint8_t tbd6; // Internal speaker volume
+    uint8_t use_accurate_rumble;
+    uint8_t tbd7[5];
     uint32_t leds;
-    uint8_t tbd2[24];
+    uint8_t tbd8[24];
     uint32_t crc;
 } __packed;
 


### PR DESCRIPTION
This PR adds DualSense trigger effects to simulate a "click" when mapped to a digital button.

Currently, we reference the [DS4Windows code](https://github.com/Ryochan7/DS4Windows/blob/master/DS4Windows/DS4Library/InputDevices/DualSenseDevice.cs)'s way to find the corresponding values to send to the controller from the `perc_threshold` setting for the trigger buttons. We make the trigger click when it reaches the configured threshold, simulating a digital button at some point in the middle of the travel.

The trigger effect is turned on when rumble is turned on. Here is the logic:

- If rumble is turned off, don't enable the haptic triggers
- Otherwise, look through the adapter mappings for the PS5's `PAD_RM` and `PAD_LM` (R2 and L2):
  - If we find a mapping to an analog axis, skip
  - If we find a mapping to a digital button, use its threshold to set the trigger's haptic point. If there are multiple mappings to digital buttons, use the highest threshold found.
  - If there is only one mapping overall for the trigger, don't enable haptics.

The above logic works out nicely, and will feel pretty authentic in most cases.

1. For consoles with just analog L/R, the triggers won't click in most peoples' configurations.
2. For consoles with just digital L/R, the triggers won't click by default if there's just one mapping. The triggers can be set up to click by adding an additional digital mapping.
3. For GameCube, which has both analog and digital L/R on the same button, they will click at the _digital_ threshold point.

Demo video: https://www.youtube.com/watch?v=nUx-Em1jNR8

Fixes #483 