### PR TITLE
Fix 8bitdo Neo Geo Shoulder buttons

### DIFF
--- a/main/bluetooth/hidp/hidp.c
+++ b/main/bluetooth/hidp/hidp.c
@@ -43,7 +43,7 @@ static const struct bt_name_type bt_name_type[] = {
     {"8BitDo GBros Adapter", BT_XBOX, BT_8BITDO_GBROS, 0},
     {"8Bitdo N64 GamePad", BT_HID_GENERIC, BT_SUBTYPE_DEFAULT, BIT(BT_QUIRK_8BITDO_N64)},
     {"8BitDo N64 Modkit", BT_HID_GENERIC, BT_SUBTYPE_DEFAULT, BIT(BT_QUIRK_8BITDO_N64_MK)},
-    {"8BitDo NEOGEO GP", BT_HID_GENERIC, BT_SUBTYPE_DEFAULT, BIT(BT_QUIRK_TRIGGER_PRI_SEC_INVERT)},
+    {"8BitDo NEOGEO GP", BT_HID_GENERIC, BT_SUBTYPE_DEFAULT, 0},
     {"8BitDo M30 gamepad", BT_XBOX, BT_XBOX_XINPUT, BIT(BT_QUIRK_8BITDO_M30)},
     {"8BitDo S30 Modkit", BT_XBOX, BT_XBOX_XINPUT, BIT(BT_QUIRK_8BITDO_SATURN)},
     {"8BitDo Retro Keyboard", BT_HID_GENERIC, BT_SUBTYPE_DEFAULT, 0}, /* Need to be exluded from 8bitdo catch all */


### PR DESCRIPTION
#933 Fix issue with 8bitdo NeoGeo pad shoulder buttons not detected.  The 8bitdo Neo Geo Pad is most like the 8BitDo SNES pads with just L1 and R1 shoulder buttons.  In version 1.8.4 this line didn't exist at all and it just defaulted to default 8bitdo settings.  Compiled this locally and tested and it seemed to fix the problem.