### PR TITLE
[HW2 internal] Adding power off and fallback

### DIFF
--- a/main/adapter/config.c
+++ b/main/adapter/config.c
@@ -21,7 +21,7 @@ struct hw_config hw_config = {
     .hotplug = 0,
     .hw1_ports_led_pins = {2, 4, 12, 15},
     .led_flash_duty_cycle = 0x80000,
-    .led_flash_hz = {2, 4, 8},
+    .led_flash_hz = {2, 4, 8, 12},
     .led_flash_off_duty_cycle = 0,
     .led_flash_on_duty_cycle = 0xFFFFF,
     .led_pulse_duty_max = 2000,
@@ -44,7 +44,7 @@ struct hw_config hw_config = {
     .reset_pin_od = 1,
     .reset_pin_polarity = 0,
     .reset_pin_pulse_ms = 500,
-    .sw_io0_hold_thres_ms = {1000, 3000, 6000},
+    .sw_io0_hold_thres_ms = {1000, 3000, 6000, 8000},
     .ps_ctrl_colors = {
         0xFF0000, /* Blue */
         0x0000FF, /* Red */

--- a/main/adapter/config.h
+++ b/main/adapter/config.h
@@ -65,7 +65,7 @@ struct hw_config {
             uint32_t hotplug;
             uint32_t hw1_ports_led_pins[4];
             uint32_t led_flash_duty_cycle;
-            uint32_t led_flash_hz[3];
+            uint32_t led_flash_hz[4];
             uint32_t led_flash_off_duty_cycle;
             uint32_t led_flash_on_duty_cycle;
             uint32_t led_pulse_duty_max;
@@ -88,7 +88,7 @@ struct hw_config {
             uint32_t reset_pin_od;
             uint32_t reset_pin_polarity;
             uint32_t reset_pin_pulse_ms;
-            uint32_t sw_io0_hold_thres_ms[3];
+            uint32_t sw_io0_hold_thres_ms[4];
             uint32_t ps_ctrl_colors[8];
         };
         uint32_t data32[43];

--- a/main/system/manager.c
+++ b/main/system/manager.c
@@ -388,7 +388,8 @@ static void boot_btn_hdl(void) {
                 default:
                     break;
             }
-            set_leds_as_btn_status(1);  
+            set_leds_as_btn_status(1);
+            return;
         }
             
         else {
@@ -416,6 +417,7 @@ static void boot_btn_hdl(void) {
                     break;
             }
             set_leds_as_btn_status(0);
+            return;
         }
 
         /* Inhibit SW press for 2 seconds */

--- a/main/system/manager.c
+++ b/main/system/manager.c
@@ -388,10 +388,9 @@ static void boot_btn_hdl(void) {
                 default:
                     break;
             }
-            set_leds_as_btn_status(1);
-            return;
         }
-            
+        set_leds_as_btn_status(1);
+      
         else {
             switch (state) {
                 case SYS_MGR_BTN_STATE0:
@@ -416,10 +415,9 @@ static void boot_btn_hdl(void) {
                     sys_mgr_factory_reset();
                     break;
             }
-            set_leds_as_btn_status(0);
-            return;
         }
-
+        set_leds_as_btn_status(0);
+      
         /* Inhibit SW press for 2 seconds */
         vTaskDelay(2000 / portTICK_PERIOD_MS);
     }

--- a/main/system/manager.c
+++ b/main/system/manager.c
@@ -389,7 +389,6 @@ static void boot_btn_hdl(void) {
                     break;
             }
             set_leds_as_btn_status(1);  
-            return;
         }
             
         else {
@@ -416,9 +415,9 @@ static void boot_btn_hdl(void) {
                     sys_mgr_factory_reset();
                     break;
             }
+            set_leds_as_btn_status(0);
         }
 
-        set_leds_as_btn_status(0);
         /* Inhibit SW press for 2 seconds */
         vTaskDelay(2000 / portTICK_PERIOD_MS);
     }

--- a/main/system/manager.c
+++ b/main/system/manager.c
@@ -388,9 +388,8 @@ static void boot_btn_hdl(void) {
                 default:
                     break;
             }
+            set_leds_as_btn_status(1);
         }
-        set_leds_as_btn_status(1);
-      
         else {
             switch (state) {
                 case SYS_MGR_BTN_STATE0:
@@ -415,9 +414,8 @@ static void boot_btn_hdl(void) {
                     sys_mgr_factory_reset();
                     break;
             }
-        }
-        set_leds_as_btn_status(0);
-      
+            set_leds_as_btn_status(0);
+        }     
         /* Inhibit SW press for 2 seconds */
         vTaskDelay(2000 / portTICK_PERIOD_MS);
     }

--- a/main/system/manager.c
+++ b/main/system/manager.c
@@ -384,9 +384,12 @@ static void boot_btn_hdl(void) {
 
         switch (state) {
             case SYS_MGR_BTN_STATE0:
-                sys_mgr_power_off();
+                sys_mgr_reset();
                 break;
             case SYS_MGR_BTN_STATE1:
+                sys_mgr_power_off();
+                break;
+            case SYS_MGR_BTN_STATE2:
                 if (bt_hci_get_inquiry()) {
                     bt_hci_stop_inquiry();
                 }
@@ -394,12 +397,10 @@ static void boot_btn_hdl(void) {
                     bt_host_disconnect_all();
                 }
                 break;
-            case SYS_MGR_BTN_STATE2:
+            case SYS_MGR_BTN_STATE3:
                 bt_hci_start_inquiry();
                 break;
-            case SYS_MGR_BTN_STATE3:
-                sys_mgr_reset();
-                break;
+
             default:
                 sys_mgr_factory_reset();
                 break;

--- a/main/system/manager.c
+++ b/main/system/manager.c
@@ -58,6 +58,7 @@ enum {
     SYS_MGR_BTN_STATE1,
     SYS_MGR_BTN_STATE2,
     SYS_MGR_BTN_STATE3,
+    SYS_MGR_BTN_STATE4,
 };
 
 #ifdef CONFIG_BLUERETRO_HW2
@@ -366,7 +367,7 @@ static void boot_btn_hdl(void) {
 
         while (sys_mgr_get_boot_btn()) {
             hold_cnt++;
-            if (hold_cnt > (hw_config.sw_io0_hold_thres_ms[state] / 10) && state < SYS_MGR_BTN_STATE3) {
+            if (hold_cnt > (hw_config.sw_io0_hold_thres_ms[state] / 10) && state < SYS_MGR_BTN_STATE4) {
                 ledc_set_duty_and_update(LEDC_LOW_SPEED_MODE, LEDC_CHANNEL_1, hw_config.led_flash_duty_cycle, 0);
                 ledc_set_freq(LEDC_LOW_SPEED_MODE, LEDC_TIMER_1, hw_config.led_flash_hz[state]);
                 state++;
@@ -395,6 +396,9 @@ static void boot_btn_hdl(void) {
                 break;
             case SYS_MGR_BTN_STATE2:
                 bt_hci_start_inquiry();
+                break;
+            case SYS_MGR_BTN_STATE3:  // Fügen Sie den neuen Zustand hinzu
+                sys_mgr_power_off();
                 break;
             default:
                 sys_mgr_factory_reset();

--- a/main/system/manager.c
+++ b/main/system/manager.c
@@ -358,6 +358,8 @@ static void boot_btn_hdl(void) {
     uint32_t state = 0;
 
   if (sys_mgr_get_boot_btn()) {
+       set_leds_as_btn_status(1); // set LED status
+      
         while (sys_mgr_get_boot_btn()) {
             hold_cnt++;
             if (hold_cnt > (hw_config.sw_io0_hold_thres_ms[state] / 10) && state < SYS_MGR_BTN_STATE4) {
@@ -380,7 +382,7 @@ static void boot_btn_hdl(void) {
                 case SYS_MGR_BTN_STATE0:
                     sys_mgr_power_on();
                     break;
-                case SYS_MGR_BTN_STATE1: /* fallback reset */
+                case SYS_MGR_BTN_STATE1: // fallback reset
                     set_reset(0);
                     sys_mgr_power_on();
                     set_reset(1);
@@ -395,7 +397,7 @@ static void boot_btn_hdl(void) {
                 case SYS_MGR_BTN_STATE0:
                     sys_mgr_reset();
                     break;
-                case SYS_MGR_BTN_STATE1: /* power off */
+                case SYS_MGR_BTN_STATE1: // power off
                     sys_mgr_power_off();
                     break;
                 case SYS_MGR_BTN_STATE2:
@@ -414,10 +416,10 @@ static void boot_btn_hdl(void) {
                     sys_mgr_factory_reset();
                     break;
             }
-            set_leds_as_btn_status(0);
-        }     
-        /* Inhibit SW press for 2 seconds */
-        vTaskDelay(2000 / portTICK_PERIOD_MS);
+        }   
+      set_leds_as_btn_status(0); //reset LED-Status
+      /* Inhibit SW press for 2 seconds */
+      vTaskDelay(2000 / portTICK_PERIOD_MS);
     }
 }
 

--- a/main/system/manager.c
+++ b/main/system/manager.c
@@ -384,7 +384,7 @@ static void boot_btn_hdl(void) {
 
         switch (state) {
             case SYS_MGR_BTN_STATE0:
-                sys_mgr_reset();
+                sys_mgr_power_off();
                 break;
             case SYS_MGR_BTN_STATE1:
                 if (bt_hci_get_inquiry()) {
@@ -397,8 +397,8 @@ static void boot_btn_hdl(void) {
             case SYS_MGR_BTN_STATE2:
                 bt_hci_start_inquiry();
                 break;
-            case SYS_MGR_BTN_STATE3:  // shut down
-                sys_mgr_power_off();
+            case SYS_MGR_BTN_STATE3:
+                sys_mgr_reset();
                 break;
             default:
                 sys_mgr_factory_reset();

--- a/main/system/manager.c
+++ b/main/system/manager.c
@@ -397,7 +397,7 @@ static void boot_btn_hdl(void) {
             case SYS_MGR_BTN_STATE2:
                 bt_hci_start_inquiry();
                 break;
-            case SYS_MGR_BTN_STATE3:  // Fügen Sie den neuen Zustand hinzu
+            case SYS_MGR_BTN_STATE3:  // shut down
                 sys_mgr_power_off();
                 break;
             default:


### PR DESCRIPTION
Adding new buttonstate and adding power off as buttonstate 1 (press reset for 3 seconds). Moving other buttonstates 3 seconds out. 

Adding fallback strategy for other mods using reset during power on. Long press reset (>3sec) when power state of the console is off, will power on the console while sending the reset signal to the console.